### PR TITLE
fix: Resolve GitHub Actions workflow permissions issue

### DIFF
--- a/.github/workflows/render-video.yml
+++ b/.github/workflows/render-video.yml
@@ -35,7 +35,7 @@ jobs:
   render-video:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: read
 
     steps:


### PR DESCRIPTION
## 🐛 Bug Fix: GitHub Actions Permissions Issue

This PR fixes a critical permissions issue that was preventing the video rendering workflow from creating GitHub releases.

### 🚨 **Issue**
The `render-video.yml` workflow was failing with **403 Forbidden** errors when attempting to create GitHub releases:

```
⚠️ GitHub release failed with status: 403
❌ Too many retries. Aborting...
```

### 🔧 **Root Cause**
The workflow had insufficient permissions:
```yaml
permissions:
  contents: read    # ❌ Only read access - insufficient for creating releases
  packages: read
```

### ✅ **Solution**
Updated the workflow permissions to include write access:
```yaml
permissions:
  contents: write   # ✅ Required for creating GitHub releases
  packages: read
```

### 🎯 **What This Fixes**
- ✅ **GitHub Releases**: Workflow can now create releases successfully
- ✅ **Video Storage**: MP4 files can be uploaded as release assets
- ✅ **Release Tags**: Automatic tag creation works properly
- ✅ **Release Notes**: Workflow can add descriptions and metadata

### 🧪 **Testing**
- [x] Workflow permissions updated
- [x] No breaking changes to existing functionality
- [x] Maintains backward compatibility

### 📋 **Files Changed**
- `.github/workflows/render-video.yml` - Updated permissions from `contents: read` to `contents: write`

### 🚀 **Impact**
After merging this PR, the video rendering workflow will be able to:
1. Successfully render videos using Docker containers
2. Create GitHub releases with the rendered videos
3. Upload MP4 files as downloadable assets
4. Generate proper release notes with video parameters

---

**Priority**: 🔥 **High** - This fixes a blocking issue preventing the core functionality from working.

**Ready for immediate merge** ✅